### PR TITLE
Refactor Permutation struct's use of R_f and R_F

### DIFF
--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -167,7 +167,7 @@ impl Permutation {
         }
 
         // Apply R_f full rounds
-        for _ in 0..fulll_rounds_iter / 2{
+        for _ in 0..fulll_rounds_iter{
             new_words = self.constrain_apply_full_round(&mut constants_iter, new_words, cs)?;
             new_words = new_words.into_iter().map(|word| word.simplify()).collect();
         }

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -22,7 +22,7 @@ pub struct Permutation {
 impl Default for Permutation {
     fn default() -> Self {
         let width = 9;
-        let full_founds = 8;
+        let full_founds = 4;
         let partial_rounds = 59;
         Permutation {
             t: width,
@@ -37,12 +37,12 @@ impl Default for Permutation {
 }
 
 impl Permutation {
-    pub fn new(t: usize, full_rounds: usize, partial_rounds: usize) -> Result<Self, PermError> {
-        if full_rounds % 2 != 0 {
-            return Err(PermError::FullRoundsOdd);
-        }
-
-        let perm = Permutation {
+    // `full_rounds` input aims to be the number of full rounds that will be done
+    // before the partial rounds AND (BUT NOT ADDED TO) the number of full rounds 
+    // that will be done after the partial rounds.
+    pub fn new(t: usize, full_rounds: usize, partial_rounds: usize) -> Self {
+        
+        Permutation {
             t: t,
             full_rounds: full_rounds,
             partial_rounds: partial_rounds,
@@ -50,9 +50,7 @@ impl Permutation {
             data_lc: Vec::with_capacity(t),
             constants: RoundConstants::generate(full_rounds, partial_rounds, t),
             matrix: MDSMatrix::generate(t),
-        };
-
-        Ok(perm)
+        }
     }
 }
 
@@ -125,7 +123,7 @@ impl Permutation {
         let mut new_words: Vec<Scalar> = self.data.clone();
 
         // Apply R_f full rounds
-        for _ in 0..self.full_rounds / 2 {
+        for _ in 0..self.full_rounds {
             new_words = self.apply_full_round(&mut constants_iter, new_words)?;
         }
 
@@ -135,7 +133,7 @@ impl Permutation {
         }
 
         // Apply R_f full rounds
-        for _ in 0..self.full_rounds / 2 {
+        for _ in 0..self.full_rounds {
             new_words = self.apply_full_round(&mut constants_iter, new_words)?;
         }
 

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -22,7 +22,7 @@ pub struct Permutation {
 impl Default for Permutation {
     fn default() -> Self {
         let width = 9;
-        let full_founds = 8;
+        let total_full_founds = 8;
         let partial_rounds = 59;
         Permutation {
             t: width,

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -7,7 +7,7 @@ use sha2::Sha512;
 
 pub struct Permutation {
     t: usize,
-    full_rounds: usize,
+    total_full_rounds: usize,
     partial_rounds: usize,
 
     // data to be used in the solid instantiation of the permutation struct
@@ -26,7 +26,7 @@ impl Default for Permutation {
         let partial_rounds = 59;
         Permutation {
             t: width,
-            full_rounds: total_full_founds,
+            total_full_rounds: total_full_founds,
             partial_rounds: partial_rounds,
             data: Vec::with_capacity(width),
             data_lc: Vec::with_capacity(width),
@@ -43,7 +43,7 @@ impl Permutation {
 
         Permutation {
             t: t,
-            full_rounds: total_full_rounds,
+            total_full_rounds: total_full_rounds,
             partial_rounds: R_p,
             data: Vec::with_capacity(t),
             data_lc: Vec::with_capacity(t),
@@ -117,14 +117,12 @@ impl Permutation {
         // Pad remaining width with zero
         self.pad();
 
-        let fulll_rounds_iter = self.full_rounds / 2;
-
         let mut constants_iter = self.constants.iter();
 
         let mut new_words: Vec<Scalar> = self.data.clone();
 
         // Apply R_f full rounds
-        for _ in 0..fulll_rounds_iter {
+        for _ in 0..self.total_full_rounds / 2 {
             new_words = self.apply_full_round(&mut constants_iter, new_words)?;
         }
 
@@ -134,7 +132,7 @@ impl Permutation {
         }
 
         // Apply R_f full rounds
-        for _ in 0..fulll_rounds_iter {
+        for _ in 0..self.total_full_rounds / 2 {
             new_words = self.apply_full_round(&mut constants_iter, new_words)?;
         }
 
@@ -152,10 +150,8 @@ impl Permutation {
 
         let mut new_words = self.data_lc.clone();
 
-        let fulll_rounds_iter = self.full_rounds / 2;
-
         // Apply R_f full rounds
-        for _ in 0..fulll_rounds_iter{
+        for _ in 0..self.total_full_rounds / 2{
             new_words = self.constrain_apply_full_round(&mut constants_iter, new_words, cs)?;
             new_words = new_words.into_iter().map(|word| word.simplify()).collect();
         }
@@ -167,7 +163,7 @@ impl Permutation {
         }
 
         // Apply R_f full rounds
-        for _ in 0..fulll_rounds_iter{
+        for _ in 0..self.total_full_rounds / 2{
             new_words = self.constrain_apply_full_round(&mut constants_iter, new_words, cs)?;
             new_words = new_words.into_iter().map(|word| word.simplify()).collect();
         }

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -152,7 +152,7 @@ impl Permutation {
         let mut new_words = self.data_lc.clone();
 
         // Apply R_f full rounds
-        for _ in 0..self.full_rounds / 2 {
+        for _ in 0..self.full_rounds {
             new_words = self.constrain_apply_full_round(&mut constants_iter, new_words, cs)?;
             new_words = new_words.into_iter().map(|word| word.simplify()).collect();
         }
@@ -164,7 +164,7 @@ impl Permutation {
         }
 
         // Apply R_f full rounds
-        for _ in 0..self.full_rounds / 2 {
+        for _ in 0..self.full_rounds {
             new_words = self.constrain_apply_full_round(&mut constants_iter, new_words, cs)?;
             new_words = new_words.into_iter().map(|word| word.simplify()).collect();
         }

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -26,11 +26,11 @@ impl Default for Permutation {
         let partial_rounds = 59;
         Permutation {
             t: width,
-            full_rounds: full_founds,
+            full_rounds: total_full_founds,
             partial_rounds: partial_rounds,
             data: Vec::with_capacity(width),
             data_lc: Vec::with_capacity(width),
-            constants: RoundConstants::generate(full_founds, partial_rounds, width),
+            constants: RoundConstants::generate(total_full_founds, partial_rounds, width),
             matrix: MDSMatrix::generate(width),
         }
     }


### PR DESCRIPTION
To provide a more friendly API, we want to remove the results from the `Permutation` constructing functions. 

This is explained on #2 .

To differentiate between R_f and R_F. We will call `total_full_rounds` R_F and `full_rounds` R_f.

- The permutation struct will be initialised with R_f instead of R_F. This will avoid the code needing to check if R_F is even.

- The permutation struct has a field called `full_rounds`. This is actually the `total_full_rounds` and therefore we will change the field name to show this.