### PR TITLE
Add LinearCombination benches

### DIFF
--- a/benches/poseidon_benches.rs
+++ b/benches/poseidon_benches.rs
@@ -57,6 +57,8 @@ mod lc_benches {
     fn digest_one() -> () {
         let s = LinearCombination::from(Scalar::random(&mut thread_rng()));
 
+        // The creation of the `Verifier` does not affect at the benchmark timings.
+        // It takes aproximately: `625.21 ns`.
         let mut verifier_transcript = Transcript::new(b"");
         let mut verifier = Verifier::new(&mut verifier_transcript);
 
@@ -67,6 +69,8 @@ mod lc_benches {
     fn digest(n: usize) -> () {
         let s: Vec<LinearCombination> = (0..n).map(|_| LinearCombination::from(Scalar::random(&mut thread_rng()))).collect();
         
+        // The creation of the `Verifier` does not affect at the benchmark timings.
+        // It takes aproximately: `625.21 ns`.
         let mut verifier_transcript = Transcript::new(b"");
         let mut verifier = Verifier::new(&mut verifier_transcript);
 

--- a/benches/poseidon_benches.rs
+++ b/benches/poseidon_benches.rs
@@ -13,39 +13,87 @@ use merlin::Transcript;
 use hades252::linear_combination;
 use hades252::scalar;
 
-/// This function allows us to bench the whole process of
-/// digesting a vec of `Scalar`. We put together the process
-/// of creating the scalar array + digesting the info to be able
-/// to compare the results against the unoptimized version.
-#[inline]
-fn digest_one() -> () {
-    let s = Scalar::random(&mut thread_rng());
-    scalar::hash(&[s]).unwrap();
+
+mod scalar_benches {
+    use super::*;
+
+    /// This function allows us to bench the whole process of
+    /// digesting a vec of `Scalar`. We put together the process
+    /// of creating the scalar array + digesting the info to be able
+    /// to compare the results against the unoptimized version.
+    #[inline]
+    fn digest_one() -> () {
+        let s = Scalar::random(&mut thread_rng());
+        scalar::hash(&[s]).unwrap();
+    }
+
+    #[inline]
+    fn digest(n: usize) -> () {
+        let s: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut thread_rng())).collect();
+        scalar::hash(&s).unwrap();
+    }
+
+    pub fn hash_one_scalar(c: &mut Criterion) {
+        c.bench_function("Hashing single `Scalar`", |b| b.iter(|| digest_one()));
+    }
+
+    pub fn hash_two_scalars(c: &mut Criterion) {
+        c.bench_function("Hashing two `Scalar`", |b| b.iter(|| digest(black_box(2))));
+    }
+
+    pub fn hash_four_scalars(c: &mut Criterion) {
+        c.bench_function("Hashing four `Scalar`", |b| b.iter(|| digest(black_box(4))));
+    }
 }
 
-#[inline]
-fn digest(n: usize) -> () {
-    let s: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut thread_rng())).collect();
-    scalar::hash(&s).unwrap();
-}
+mod lc_benches {
+    use super::*;
 
-pub fn hash_one_scalar(c: &mut Criterion) {
-    c.bench_function("Hashing single `Scalar`", |b| b.iter(|| digest_one()));
-}
+    /// This function allows us to bench the whole process of
+    /// digesting a vec of `LinearCombination`. We put together the process
+    /// of creating the linearcombination array + digesting the info to be able
+    /// to compare the results against the unoptimized version.
+    #[inline]
+    fn digest_one() -> () {
+        let s = LinearCombination::from(Scalar::random(&mut thread_rng()));
 
-pub fn hash_two_scalars(c: &mut Criterion) {
-    c.bench_function("Hashing two `Scalar`", |b| b.iter(|| digest(black_box(2))));
-}
+        let mut verifier_transcript = Transcript::new(b"");
+        let mut verifier = Verifier::new(&mut verifier_transcript);
 
-pub fn hash_four_scalars(c: &mut Criterion) {
-    c.bench_function("Hashing four `Scalar`", |b| b.iter(|| digest(black_box(4))));
+        linear_combination::hash(&mut verifier, &[s]).unwrap();
+    }
+
+    #[inline]
+    fn digest(n: usize) -> () {
+        let s: Vec<LinearCombination> = (0..n).map(|_| LinearCombination::from(Scalar::random(&mut thread_rng()))).collect();
+        
+        let mut verifier_transcript = Transcript::new(b"");
+        let mut verifier = Verifier::new(&mut verifier_transcript);
+
+        linear_combination::hash(&mut verifier, s.as_slice()).unwrap();
+    }
+
+    pub fn hash_one_lc(c: &mut Criterion) {
+        c.bench_function("Hashing single `LinearCombination`", |b| b.iter(|| digest_one()));
+    }
+
+    pub fn hash_two_lcs(c: &mut Criterion) {
+        c.bench_function("Hashing two `LinearCombination`", |b| b.iter(|| digest(black_box(2))));
+    }
+
+    pub fn hash_four_lcs(c: &mut Criterion) {
+        c.bench_function("Hashing four `LinearCombination`", |b| b.iter(|| digest(black_box(4))));
+    }
 }
 
 criterion_group!(
     benches,
-    hash_one_scalar,
-    hash_two_scalars,
-    hash_four_scalars
+    scalar_benches::hash_one_scalar,
+    scalar_benches::hash_two_scalars,
+    scalar_benches::hash_four_scalars,
+    lc_benches::hash_one_lc,
+    lc_benches::hash_two_lcs,
+    lc_benches::hash_four_lcs
 );
 
 criterion_main!(benches);


### PR DESCRIPTION
The problem I found is that we need to create the `ConstraintSystem` to be able to call `hash`.
This forces me to create a `merlin Transcript` and from there, create a `Verifier` which is passed as a `&mut ConstraintSystem`.

Also, we maybe want to generate the `Transcript` with random bytes in order to not allow the compiler to optimize the creation of it.

Any suggestions? 