### PR TITLE
Implement benches for LC_Permutation in old impl

### DIFF
--- a/benches/poseidon_benchmarks.rs
+++ b/benches/poseidon_benchmarks.rs
@@ -61,6 +61,8 @@ mod lc_benches {
         let mut hasher = Hash::new();
         let s = LinearCombination::from(Scalar::random(&mut thread_rng()));
 
+        // The creation of the `Verifier` does not affect at the benchmark timings.
+        // It takes aproximately: `625.21 ns`.
         let mut verifier_transcript = Transcript::new(b"");
         let mut verifier = Verifier::new(&mut verifier_transcript);
 
@@ -76,6 +78,8 @@ mod lc_benches {
             hasher.input_lc(lc).unwrap()
         };
         
+        // The creation of the `Verifier` does not affect at the benchmark timings.
+        // It takes aproximately: `625.21 ns`.
         let mut verifier_transcript = Transcript::new(b"");
         let mut verifier = Verifier::new(&mut verifier_transcript);
 

--- a/benches/poseidon_benchmarks.rs
+++ b/benches/poseidon_benchmarks.rs
@@ -7,48 +7,103 @@ use criterion::black_box;
 use criterion::Criterion;
 use rand::thread_rng;
 
-use bulletproofs::r1cs::LinearCombination;
+use bulletproofs::r1cs::{LinearCombination, Verifier};
+use merlin::Transcript;
 use curve25519_dalek::scalar::Scalar;
 use hades252::hash::Hash;
 
-/// This function allows us to bench the whole process of
-/// digesting a vec of `Scalar`. Since the hasher instantiation
-/// time matters here, and is optimized or even non-existing on other
-/// implementations, that makes us bench the whole process instead of
-/// just benching the `hasher.result()` fn.
-#[inline]
-fn digest_one() -> () {
-    let mut hasher = Hash::new();
-    let s = Scalar::random(&mut thread_rng());
-    hasher.input(s).unwrap();
-    hasher.result();
+mod scalar_benches {
+    use super::*;
+    
+    /// This function allows us to bench the whole process of
+    /// digesting a vec of `Scalar`. Since the hasher instantiation
+    /// time matters here, and is optimized or even non-existing on other
+    /// implementations, that makes us bench the whole process instead of
+    /// just benching the `hasher.result()` fn.
+    #[inline]
+    fn digest_one() -> () {
+        let mut hasher = Hash::new();
+        let s = Scalar::random(&mut thread_rng());
+        hasher.input(s).unwrap();
+        hasher.result();
+    }
+
+    #[inline]
+    fn digest(n: usize) -> () {
+        let mut hasher = Hash::new();
+        let s: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut thread_rng())).collect();
+        hasher.inputs(s).unwrap();
+        hasher.result();
+    }
+
+    pub fn hash_one_scalar(c: &mut Criterion) {
+        c.bench_function("Hashing single `Scalar`", |b| b.iter(|| digest_one()));
+    }
+
+    pub fn hash_two_scalars(c: &mut Criterion) {
+        c.bench_function("Hashing two `Scalar`", |b| b.iter(|| digest(black_box(2))));
+    }
+
+    pub fn hash_four_scalars(c: &mut Criterion) {
+        c.bench_function("Hashing four `Scalar`", |b| b.iter(|| digest(black_box(4))));
+    }
 }
 
-#[inline]
-fn digest(n: usize) -> () {
-    let mut hasher = Hash::new();
-    let s: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut thread_rng())).collect();
-    hasher.inputs(s).unwrap();
-    hasher.result();
+mod lc_benches {
+    use super::*;
+
+    /// This function allows us to bench the whole process of
+    /// digesting a vec of `LinearCombination`. We put together the process
+    /// of creating the linearcombination array + digesting the info to be able
+    /// to compare the results against the unoptimized version.
+    #[inline]
+    fn digest_one() -> () {
+        let mut hasher = Hash::new();
+        let s = LinearCombination::from(Scalar::random(&mut thread_rng()));
+
+        let mut verifier_transcript = Transcript::new(b"");
+        let mut verifier = Verifier::new(&mut verifier_transcript);
+
+        hasher.input_lc(s).unwrap();
+        hasher.result_gadget(&mut verifier).unwrap();
+    }
+
+    #[inline]
+    fn digest(n: usize) -> () {
+        let mut hasher = Hash::new();
+        let lcs: Vec<LinearCombination> = (0..n).map(|_| LinearCombination::from(Scalar::random(&mut thread_rng()))).collect();
+        for lc in lcs {
+            hasher.input_lc(lc).unwrap()
+        };
+        
+        let mut verifier_transcript = Transcript::new(b"");
+        let mut verifier = Verifier::new(&mut verifier_transcript);
+
+        hasher.result_gadget(&mut verifier).unwrap();
+    }
+
+    pub fn hash_one_lc(c: &mut Criterion) {
+        c.bench_function("Hashing single `LinearCombination`", |b| b.iter(|| digest_one()));
+    }
+
+    pub fn hash_two_lcs(c: &mut Criterion) {
+        c.bench_function("Hashing two `LinearCombination`", |b| b.iter(|| digest(black_box(2))));
+    }
+
+    pub fn hash_four_lcs(c: &mut Criterion) {
+        c.bench_function("Hashing four `LinearCombination`", |b| b.iter(|| digest(black_box(4))));
+    }
 }
 
-pub fn hash_one_scalar(c: &mut Criterion) {
-    c.bench_function("Hashing single `Scalar`", |b| b.iter(|| digest_one()));
-}
-
-pub fn hash_two_scalars(c: &mut Criterion) {
-    c.bench_function("Hashing two `Scalar`", |b| b.iter(|| digest(black_box(2))));
-}
-
-pub fn hash_four_scalars(c: &mut Criterion) {
-    c.bench_function("Hashing four `Scalar`", |b| b.iter(|| digest(black_box(4))));
-}
 
 criterion_group!(
     benches,
-    hash_one_scalar,
-    hash_two_scalars,
-    hash_four_scalars
+    scalar_benches::hash_one_scalar,
+    scalar_benches::hash_two_scalars,
+    scalar_benches::hash_four_scalars,
+    lc_benches::hash_one_lc,
+    lc_benches::hash_two_lcs,
+    lc_benches::hash_four_lcs
 );
 
 criterion_main!(benches);


### PR DESCRIPTION
The results make sense in terms of the time increment that the benches output respectively to the new implementation.

The `LinearCombination` part it's quite obfuscated with the `Verifier` creation.

This is the time that it takes for a single `LinearCombination` with the new hash impl:
```
Benchmarking Hashing single `LinearCombination`: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 232.3s or reduce sample count to 10
Hashing single `LinearCombination`                                                                             
                        time:   [45.733 ms 45.747 ms 45.763 ms]
                        change: [-1.4846% -0.8862% -0.3177%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
```

This is what it takes for the old hash impl with for `LinearCombination`.
```
Benchmarking Hashing single `LinearCombination`: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 210.3s or reduce sample count to 10
Hashing single `LinearCombination`                                                                             
                        time:   [40.837 ms 41.015 ms 41.231 ms]
                        change: [-10.342% -9.7486% -9.0932%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  10 (10.00%) high mild
  4 (4.00%) high severe

```

Maybe we can remove the `Verifier` creation out of the 