### PR TITLE
Refactor GadgetStrategy structure and API interaction

### DIFF
--- a/src/strategies/gadget.rs
+++ b/src/strategies/gadget.rs
@@ -330,7 +330,6 @@ mod tests {
         ) -> (StandardComposer, Vec<BlsScalar>) {
             let mut perm: [Variable; WIDTH] = [unsafe { mem::zeroed() }; WIDTH];
             let mut composer = StandardComposer::new();
-            let mut pi = vec![BlsScalar::zero(); CAPACITY];
 
             let zero = composer.add_input(BlsScalar::zero());
 

--- a/src/strategies/gadget.rs
+++ b/src/strategies/gadget.rs
@@ -11,46 +11,23 @@ pub const PI_SIZE: usize = 1737;
 
 /// Implements a Hades252 strategy for `Variable` as input values.
 /// Requires a reference to a `ConstraintSystem`.
-pub struct GadgetStrategy<'a, P>
-where
-    P: Iterator<Item = &'a mut BlsScalar>,
-{
-    /// Counter over pushed PI
-    pub pi_len: usize,
+pub struct GadgetStrategy<'a> {
     /// A reference to the constraint system used by the gadgets
-    pub cs: StandardComposer,
-    /// Mutable iterator over the public inputs
-    pub pi_iter: P,
+    pub cs: &'a mut StandardComposer,
 }
 
-impl<'a, P> GadgetStrategy<'a, P>
-where
-    P: Iterator<Item = &'a mut BlsScalar>,
-{
+impl<'a> GadgetStrategy<'a> {
     /// Constructs a new `GadgetStrategy` with the constraint system.
-    pub fn new(cs: StandardComposer, pi_iter: P) -> Self {
-        GadgetStrategy {
-            pi_len: 0,
-            cs,
-            pi_iter,
-        }
-    }
-
-    /// Return the inner iterator over public inputs
-    pub fn into_inner(self) -> (StandardComposer, P) {
-        (self.cs, self.pi_iter)
+    pub fn new(cs: &'a mut StandardComposer) -> Self {
+        GadgetStrategy { cs }
     }
 
     /// Perform the hades permutation on a plonk circuit
-    pub fn hades_gadget(
-        composer: StandardComposer,
-        pi: P,
-        x: &mut [Variable],
-    ) -> (StandardComposer, P) {
+    pub fn hades_gadget(composer: &'a mut StandardComposer, x: &mut [Variable]) {
         #[cfg(feature = "trace")]
         let circuit_size = composer.circuit_size();
 
-        let mut strategy = GadgetStrategy::new(composer, pi);
+        let mut strategy = GadgetStrategy::new(composer);
 
         strategy.perm(x);
 
@@ -62,48 +39,27 @@ where
                 WIDTH
             );
         }
-
-        strategy.into_inner()
     }
 
     /// Perform the poseidon hash on a plonk circuit
     pub fn poseidon_gadget(
-        composer: StandardComposer,
-        pi: P,
-        x: &mut [Variable],
-    ) -> (StandardComposer, P, Variable) {
-        let (composer, pi) = GadgetStrategy::hades_gadget(composer, pi, x);
-        (composer, pi, x[1])
+        composer: &'a mut StandardComposer,
+        inputs: &mut [Variable],
+    ) -> Variable {
+        GadgetStrategy::hades_gadget(composer, inputs);
+        inputs[1]
     }
 
     /// Perform the poseidon slice hash on a plonk circuit
-    pub fn poseidon_slice_gadget(
-        composer: StandardComposer,
-        pi: P,
-        x: &[Variable],
-    ) -> (StandardComposer, P, Variable) {
-        let mut strategy = GadgetStrategy::new(composer, pi);
+    pub fn poseidon_slice_gadget(composer: &'a mut StandardComposer, x: &[Variable]) -> Variable {
+        let mut strategy = GadgetStrategy::new(composer);
 
-        let x = strategy.poseidon_slice(x);
-
-        let (composer, pi) = strategy.into_inner();
-
-        (composer, pi, x)
-    }
-
-    fn push_pi(&mut self, p: BlsScalar) {
-        self.pi_len += 1;
-        self.pi_iter
-            .next()
-            .map(|s| *s = p)
-            .expect("Public inputs iterator depleted");
+        let res_var: Variable = strategy.poseidon_slice(x);
+        res_var
     }
 }
 
-impl<'a, P> Strategy<Variable> for GadgetStrategy<'a, P>
-where
-    P: Iterator<Item = &'a mut BlsScalar>,
-{
+impl<'a> Strategy<Variable> for GadgetStrategy<'a> {
     fn quintic_s_box(&mut self, value: &mut Variable) {
         #[cfg(feature = "trace")]
         let circuit_size = self.cs.circuit_size();
@@ -111,7 +67,6 @@ where
         let v = value.clone();
 
         (0..2).for_each(|_| {
-            self.push_pi(BlsScalar::zero());
             *value = self.cs.mul(
                 BlsScalar::one(),
                 *value,
@@ -120,9 +75,7 @@ where
                 BlsScalar::zero(),
             )
         });
-        //println!("quintic sbox1 at gate: {}", self.cs.circuit_size());
 
-        self.push_pi(BlsScalar::zero());
         *value = self.cs.mul(
             BlsScalar::one(),
             *value,
@@ -130,7 +83,6 @@ where
             BlsScalar::zero(),
             BlsScalar::zero(),
         );
-        //println!("quintic sbox2 at gate: {}", self.cs.circuit_size());
 
         #[cfg(feature = "trace")]
         {
@@ -153,7 +105,6 @@ where
             for k in 0..WIDTH / 4 {
                 let i = 4 * k;
 
-                self.push_pi(BlsScalar::zero());
                 let z1 = self.cs.add(
                     (MDS_MATRIX[j][i], values[i]),
                     (MDS_MATRIX[j][i + 1], values[i + 1]),
@@ -161,7 +112,6 @@ where
                     BlsScalar::zero(),
                 );
 
-                self.push_pi(BlsScalar::zero());
                 let z2 = self.cs.add(
                     (MDS_MATRIX[j][i + 2], values[i + 2]),
                     (MDS_MATRIX[j][i + 3], values[i + 3]),
@@ -169,7 +119,6 @@ where
                     BlsScalar::zero(),
                 );
 
-                self.push_pi(BlsScalar::zero());
                 z3 = self.cs.add(
                     (BlsScalar::one(), z1),
                     (BlsScalar::one(), z2),
@@ -181,7 +130,6 @@ where
             // TODO - Replace by compiler constant evaluation
             if WIDTH < 4 {
                 for k in 0..WIDTH {
-                    self.push_pi(BlsScalar::zero());
                     product[k] = self.cs.add(
                         (BlsScalar::one(), product[k]),
                         (MDS_MATRIX[k][j], values[j]),
@@ -190,7 +138,6 @@ where
                     );
                 }
             } else if WIDTH & 1 == 1 {
-                self.push_pi(BlsScalar::zero());
                 product[j] = self.cs.add(
                     (BlsScalar::one(), z3),
                     (MDS_MATRIX[j][WIDTH - 1], values[WIDTH - 1]),
@@ -227,7 +174,6 @@ where
                 let i = 4 * k;
 
                 let q_c = constants[i] * MDS_MATRIX[j][i] + constants[i + 1] * MDS_MATRIX[j][i + 1];
-                self.push_pi(BlsScalar::zero());
                 let z1 = self.cs.add(
                     (MDS_MATRIX[j][i], values[i]),
                     (MDS_MATRIX[j][i + 1], values[i + 1]),
@@ -237,7 +183,6 @@ where
 
                 let q_c = constants[i + 2] * MDS_MATRIX[j][i + 2]
                     + constants[i + 3] * MDS_MATRIX[j][i + 3];
-                self.push_pi(BlsScalar::zero());
                 let z2 = self.cs.add(
                     (MDS_MATRIX[j][i + 2], values[i + 2]),
                     (MDS_MATRIX[j][i + 3], values[i + 3]),
@@ -245,7 +190,6 @@ where
                     BlsScalar::zero(),
                 );
 
-                self.push_pi(BlsScalar::zero());
                 z3 = self.cs.add(
                     (BlsScalar::one(), z1),
                     (BlsScalar::one(), z2),
@@ -257,7 +201,6 @@ where
             // TODO - Replace by compiler constant evaluation
             if WIDTH < 4 {
                 for k in 0..WIDTH {
-                    self.push_pi(BlsScalar::zero());
                     product[k] = self.cs.add(
                         (BlsScalar::one(), product[k]),
                         (MDS_MATRIX[k][j], values[j]),
@@ -266,7 +209,6 @@ where
                     );
                 }
             } else if WIDTH & 1 == 1 {
-                self.push_pi(BlsScalar::zero());
                 product[j] = self.cs.add(
                     (BlsScalar::one(), z3),
                     (MDS_MATRIX[j][WIDTH - 1], values[WIDTH - 1]),
@@ -303,7 +245,6 @@ where
                 .cloned()
                 .expect("Hades252 out of ARK constants");
 
-            self.push_pi(BlsScalar::zero());
             *w = self.cs.add(
                 (BlsScalar::one(), *w),
                 (BlsScalar::zero(), self.cs.zero_var),
@@ -341,7 +282,8 @@ where
                 .zip(perm.iter_mut().skip(2))
                 .for_each(|(c, p)| *p = *c);
 
-            self.poseidon(&mut perm)
+            let var_res: Variable = self.poseidon(&mut perm);
+            var_res
         })
     }
 }
@@ -403,8 +345,7 @@ mod tests {
             });
 
             // Apply Hades gadget strategy.
-            let (mut composer, _) =
-                GadgetStrategy::hades_gadget(composer, pi.iter_mut(), &mut i_var);
+            GadgetStrategy::hades_gadget(&mut composer, &mut i_var);
 
             // Copy the result of the permutation into the perm.
             perm.copy_from_slice(&i_var);
@@ -424,7 +365,8 @@ mod tests {
             });
 
             composer.add_dummy_constraints();
-            (composer, pi)
+            //let pub_inp = composer.public_inputs().clone();
+            (composer, vec![BlsScalar::zero()])
         }
 
         // Setup OG params.
@@ -497,9 +439,6 @@ mod tests {
         let mut composer: StandardComposer = StandardComposer::new();
 
         const BITS: usize = WIDTH * 20 - 19;
-        const SLICE_PI_SIZE: usize = super::PI_SIZE * (1 + BITS / 2);
-
-        let mut pi = vec![BlsScalar::zero(); SLICE_PI_SIZE];
 
         let data: Vec<BlsScalar> = (0..BITS)
             .map(|_| BlsScalar::random(&mut rand::thread_rng()))
@@ -507,15 +446,14 @@ mod tests {
         let result = ScalarStrategy::new().poseidon_slice(data.as_slice());
         let result = composer.add_input(result);
 
-        let vars: Vec<Variable> = data.iter().map(|d| composer.add_input(*d)).collect();
-        let (mut composer, _, x) =
-            GadgetStrategy::poseidon_slice_gadget(composer, pi.iter_mut(), &vars);
+        let mut vars: Vec<Variable> = data.iter().map(|d| composer.add_input(*d)).collect();
 
-        let zero = composer.add_input(BlsScalar::zero());
+        let x = GadgetStrategy::poseidon_slice_gadget(&mut composer, &mut vars);
+
         composer.add_gate(
             result,
             x,
-            zero,
+            composer.zero_var,
             -BlsScalar::one(),
             BlsScalar::one(),
             BlsScalar::one(),
@@ -528,40 +466,16 @@ mod tests {
         let preprocessed_circuit = composer.preprocess(&ck, &mut base_transcript, &domain);
 
         // Prove
-        let mut transcript = gen_transcript();
-        let mut composer: StandardComposer = StandardComposer::new();
-
-        let mut pi = vec![BlsScalar::zero(); SLICE_PI_SIZE];
-
-        let data: Vec<BlsScalar> = (0..BITS)
-            .map(|_| BlsScalar::random(&mut rand::thread_rng()))
-            .collect();
-        let result = ScalarStrategy::new().poseidon_slice(data.as_slice());
-        let result = composer.add_input(result);
-
-        let vars: Vec<Variable> = data.iter().map(|d| composer.add_input(*d)).collect();
-        let (mut composer, _, x) =
-            GadgetStrategy::poseidon_slice_gadget(composer, pi.iter_mut(), &vars);
-
-        let zero = composer.add_input(BlsScalar::zero());
-        composer.add_gate(
-            result,
-            x,
-            zero,
-            -BlsScalar::one(),
-            BlsScalar::one(),
-            BlsScalar::one(),
-            BlsScalar::zero(),
-            BlsScalar::zero(),
-        );
-
-        composer.add_dummy_constraints();
-
-        let circuit = composer.preprocess(&ck, &mut transcript, &domain);
-        let proof = composer.prove(&ck, &circuit, &mut transcript);
+        let circuit = composer.preprocess(&ck, &mut base_transcript, &domain);
+        let proof = composer.prove(&ck, &circuit, &mut base_transcript.clone());
 
         // Verify
         let mut transcript = base_transcript.clone();
-        assert!(proof.verify(&preprocessed_circuit, &mut transcript, &vk, &pi));
+        assert!(proof.verify(
+            &preprocessed_circuit,
+            &mut transcript,
+            &vk,
+            &vec![BlsScalar::zero()]
+        ));
     }
 }

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -19,7 +19,7 @@ pub use gadget::GadgetStrategy;
 pub use scalar::ScalarStrategy;
 
 /// Defines the Hades252 strategy algorithm.
-pub trait Strategy<T: Clone> {
+pub trait Strategy<T: Clone + Copy> {
     /// Computes `input ^ 5 (mod Fp)`
     ///
     /// The modulo depends on the input you use. In our case
@@ -150,7 +150,7 @@ pub trait Strategy<T: Clone> {
     /// Perform a poseidon hash
     fn poseidon(&mut self, data: &mut [T]) -> T {
         self.perm(data);
-        data[1].clone()
+        data[1]
     }
 
     /// Perform a slice strategy


### PR DESCRIPTION
This is a proposal PR with the implementation on how the solution I envisioned in #46 will look like. Tests passing.

If you agree with me and think that this solution is better, I'll merge this into `plonk_master` and then merge #44 .

- Removes the need of holding in memory a second `StandardComposer`
and instead holding a &'a mut of it which saves memory since we don't allocate
twice the same data structure(which is quite big btw).

- Makes the gadget interaction cleaner since you just need to provide
a &mut StandardComposer in order to get the circuit added to your
Constraint System.

## Ex:
### Previous call to gadget:
```rust
let mut composer = StandardComposer::new();
let mut inputs = [BlsScalar::one(); WIDTH];
let mut pi = [BlsScalar::zero(); WIDTH];
let (mut composer, pi) = GadgetStrategy::hades_gadget(composer, &mut inputs, &pi.iter_mut());
```

### Actual call to gadget after refactor:
```rust
let mut composer = StandardComposer::new();
let mut inputs = [BlsScalar::one(); WIDTH];
GadgetStrategy::hades_gadget(&mut Composer, inputs);
// Now I have my gadget with the hades gadget printed into my internal ConstraintSystem.
```

- It is done on the way recommended on `plonk/examples` with a simpler
and cleaner API. See: https://github.com/dusk-network/plonk/blob/f2e889184961b885d9e095afe35b137165112c91/examples/3_1_final_gadget_orientation.rs#L49

- Refactored `hades_gadget`, `poseidon_gadget` & `poseidon_slice_gadget`
to work with the new `GadgetStrategy` struct.

- Removes the need of managing PI which get inserted inside of the
Composer anyway. There's no need for the user to hold the PI since they are already known and entered to the Composer.

- Refactored the tests which look much more clean and easy to understand.