### PR TITLE
Update docs according to the new impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,7 @@ cache: cargo
 os:
   - linux
 #  - osx  CodeCov doesn't support it so it's non tested now.
-
-matrix:
-  fast_finish: false
-  include:
-  - rust: nightly
-
+# Include needeed packages (Codecov)
 addons:
   apt:
     packages:
@@ -20,18 +15,24 @@ addons:
       - gcc
       - binutils-dev
 
-# Update nightly and set it for all of the directories.
-before_script:
-  - rustup update nightly
-  - rustup override set nightly
-
-
-# Main build
-script:
-  # Run tests/builds
-  - cargo check
-  - cargo build --release --verbose --all
-  - cargo test --release --verbose --all
+matrix:
+  fast_finish: false
+  include:
+  - rust: stable
+    script:
+      # Run tests/builds
+      - cargo check
+      - cargo build --release --verbose --all
+      - cargo test --release --verbose --all
+  
+  - rust: nightly
+    script:
+      # Run tests/builds
+      - cargo check
+      - cargo build --release --verbose --all
+      - cargo test --release --verbose --all
+      # Build docs
+      - cargo doc --no-deps --features nightly_docs
 
 
 # Send a notification to the Dusk build Status Telegram channel once the CI build completes
@@ -41,7 +42,7 @@ after_script:
 # Upload docs
 after_success:
 - |
-      if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+      if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
         cargo doc --no-deps &&
         echo "<meta http-equiv=refresh content=0;url=hades252/index.html>" > target/doc/index.html &&
         git clone https://github.com/davisp/ghp-import.git &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ after_script:
 after_success:
 - |
       if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
-        cargo doc --no-deps &&
+        cargo doc --no-deps --features nightly_docs &&
         echo "<meta http-equiv=refresh content=0;url=hades252/index.html>" > target/doc/index.html &&
         git clone https://github.com/davisp/ghp-import.git &&
         ./ghp-import/ghp_import.py -n -p -f -m "Documentation update." -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ build="build/build.rs"
 
 [features]
 trace = ["tracing"]
+nightly_docs = []
 
 [dependencies]
 lazy_static = "1.3.0"

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,9 @@ help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 doc: ## Generate documentation
-	@cargo rustdoc --lib
+	@cargo +nightly rustdoc --lib --features nightly_docs
 
 doc-internal: ## Generate documentation with private items
-	@cargo rustdoc --lib -- --document-private-items
-
-publish-doc: ### Publish the documentation as github pages
-	@$(call generate_docs, $(shell mktemp -d)) && \
-	git push -f https://github.com/dusk-network/$(REPO_NAME) gh-pages
+	@cargo +nightly rustdoc --lib -- --document-private-items --features nightly_docs
 
 .PHONY: help doc doc-internal publish-doc

--- a/README.md
+++ b/README.md
@@ -66,20 +66,26 @@ assert_eq!(input.len(), output.len());
 ## Example with permutation of Variables using the `GadgetStrategy`
 ```rust
 //! Proving that we know the pre-image of a hades-252 hash.
-use hades252::{BlsScalar, GadgetStrategy, ScalarStrategy, Strategy, WIDTH};
-use dusk_plonk::constraint_system::variable::Variable;
+use hades252::{BlsScalar, GadgetStrategy, Strategy, WIDTH};
 use dusk_plonk::constraint_system::composer::StandardComposer;
-use dusk_plonk::fft::EvaluationDomain;
-use merlin::Transcript;
-
 
 // Setup OG params.
 let public_parameters = PublicParameters::setup(CAPACITY, &mut rand::thread_rng()).unwrap();
 let (ck, vk) = public_parameters.trim(CAPACITY).unwrap();
 let domain = EvaluationDomain::new(CAPACITY).unwrap();
 
+// Gen composer
+let mut composer = StandardComposer::new();
 
+// Gen inputs
+let mut inputs = [Scalar::one(); WIDTH];
 
+// Call the gadget
+GadgetStrategy::hades_gadget(&mut composer, &mut inputs);
+
+// Now your composer has been filled with a hades permutation
+// inside.
+// Now you can build your proof or keep extending your circuit.
 ```
 
 ## Deviations

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Hades252
 
-Implementation of Hades252 over the Ristretto Scalar field.
+Implementation of Hades252 over the Bls12-381 Scalar field.
 
 *Unstable* : No guarantees can be made regarding the API stability.
 
@@ -32,9 +32,9 @@ environment variable `HADES252_WIDTH` to the desired number.
 
 ## Parameters
 
-- p = `2^252 + 27742317777372353535851937790883648493`
+- p = `0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`
 
-- Security level is 126 bits
+- Security level is 117 -120 bits of security [NCCG] bits.
 
 - width = 5
 
@@ -45,14 +45,14 @@ where each full round has `WIDTH` quintic S-Boxes.
 
 - Number of round constants = 960
 
-## Example with permutation of scalars
-```
-use hades252::{Fq, ScalarStrategy, Strategy};
+## Example with permutation of scalars using the `ScalarStrategy`.
+```rust
+use hades252::{BlsScalar, ScalarStrategy, Strategy, WIDTH};
 
 // Generate the inputs that will permute.
 // The number of values we can input is equivalent to `WIDTH`
 
-let input = vec![Fq::from(1u64); hades252::WIDTH];
+let input = vec![BlsScalar::from(1u64); hades252::WIDTH];
 let mut strategy = ScalarStrategy::new();
 
 let mut output = input.clone();
@@ -60,6 +60,25 @@ strategy.perm(output.as_mut_slice());
 
 assert_ne!(&input, &output);
 assert_eq!(input.len(), output.len());
+
+```
+
+## Example with permutation of Variables using the `GadgetStrategy`
+```rust
+//! Proving that we know the pre-image of a hades-252 hash.
+use hades252::{BlsScalar, GadgetStrategy, ScalarStrategy, Strategy, WIDTH};
+use dusk_plonk::constraint_system::variable::Variable;
+use dusk_plonk::constraint_system::composer::StandardComposer;
+use dusk_plonk::fft::EvaluationDomain;
+use merlin::Transcript;
+
+
+// Setup OG params.
+let public_parameters = PublicParameters::setup(CAPACITY, &mut rand::thread_rng()).unwrap();
+let (ck, vk) = public_parameters.trim(CAPACITY).unwrap();
+let domain = EvaluationDomain::new(CAPACITY).unwrap();
+
+
 
 ```
 

--- a/build/mds.rs
+++ b/build/mds.rs
@@ -1,7 +1,3 @@
-//use super::Fq;
-//use std::{fs::File, io::prelude::*};
-//
-//use num_traits::{One, Zero};
 use super::BlsScalar;
 use std::fs;
 use std::io::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,14 @@
 //#![feature(trait_alias)]
 //#![feature(external_doc)]
-//#![deny(missing_docs)]
-//#![doc(include = "../README.md")]
-//#![feature(test)]
+//!
+#![deny(missing_docs)]
+#![cfg_attr(feature = "nightly_docs", feature(external_doc))]
+#![cfg_attr(feature = "nightly_docs", doc(include = "../README.md"))]
+
 mod mds_matrix;
 mod round_constants;
 
+/// Strategies implemented for the Hades252 algorithm.
 pub mod strategies;
 
 /// Total ammount of full rounds that will be applied.
@@ -21,7 +24,4 @@ pub const WIDTH: usize = 5;
 
 pub use dusk_bls12_381::Scalar as BlsScalar;
 
-//pub use algebra::curves::bls12_381::Bls12_381;
-//pub use algebra::curves::jubjub::JubJubProjective;
-//pub use algebra::fields::jubjub::fq::Fq;
 pub use strategies::{GadgetStrategy, ScalarStrategy, Strategy};

--- a/src/round_constants.rs
+++ b/src/round_constants.rs
@@ -3,7 +3,7 @@
 //!
 //! The constants were originally computed using:
 //! https://extgit.iaik.tugraz.at/krypto/hadesmimc/blob/master/code/calc_round_numbers.py
-//! and then mapped onto `Scalar` in the Ristretto scalar field.
+//! and then mapped onto `BlsScalar` in the Bls12_381 scalar field.
 #![allow(non_snake_case)]
 use crate::BlsScalar;
 
@@ -15,8 +15,8 @@ lazy_static! {
   /// `ROUND_CONSTANTS` constists on a static reference
   /// that points to the pre-loaded 960 Fq constants.
   ///
-  /// This 960 `Fq` constants are loaded from `ark.bin`
-  /// where all of the `Fq` are represented in bytes.
+  /// This 960 `BlsScalar` constants are loaded from `ark.bin`
+  /// where all of the `BlsScalar`s are represented in bytes.
   ///
   /// This round constants have been taken from:
   /// https://extgit.iaik.tugraz.at/krypto/hadesmimc/blob/master/code/calc_round_numbers.py

--- a/src/strategies/gadget.rs
+++ b/src/strategies/gadget.rs
@@ -28,6 +28,7 @@ where
     P: Iterator<Item = &'a mut BlsScalar>,
 {
     /// Constructs a new `GadgetStrategy` with the constraint system.
+    /// In this case, the CS is embedded inside of a plonk `StandardComposer`.
     pub fn new(cs: StandardComposer, pi_iter: P) -> Self {
         GadgetStrategy {
             pi_len: 0,
@@ -41,7 +42,8 @@ where
         (self.cs, self.pi_iter)
     }
 
-    /// Perform the hades permutation on a plonk circuit
+    /// Perform the hades permutation on a plonk circuit given a set of Public
+    /// Inputs and a set of Variables used as inputs.
     pub fn hades_gadget(
         composer: StandardComposer,
         pi: P,
@@ -142,6 +144,7 @@ where
         }
     }
 
+    /// Adds a constraint for each matrix coefficient multiplication
     fn mul_matrix(&mut self, values: &mut [Variable]) {
         #[cfg(feature = "trace")]
         let circuit_size = self.cs.circuit_size();
@@ -214,7 +217,7 @@ where
         }
     }
 
-    /// Multiply the values for MDS matrix.
+    /// Multiply the values for MDS matrix in the partial round application process.
     fn mul_matrix_partial_round(&mut self, constants: &[BlsScalar], values: &mut [Variable]) {
         #[cfg(feature = "trace")]
         let circuit_size = self.cs.circuit_size();

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -1,10 +1,11 @@
-////! This module contains an implementation of the `Hades252`
-////! strategy algorithm specifically designed to work outside of
-////! Rank 1 Constraint Systems (R1CS).
-////!
-////! The inputs of the permutation function have to be explicitly
-////! over the Fq Field of the curve25519 so working over
-////! `Fp = 2^252 + 27742317777372353535851937790883648493`.
+//! This module contains an implementation of the `Hades252`
+//! strategy algorithm specifically designed to work outside of
+//! Rank 1 Constraint Systems (R1CS) or other custom Constraint
+//! Systems such as Add/Mul/Custom plonk gate-circuits.
+//!
+//! The inputs of the permutation function have to be explicitly
+//! over the Scalar Field of the bls12_381 curve so working over
+//! `Fq = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`.
 use crate::{
     round_constants::ROUND_CONSTANTS, BlsScalar, PARTIAL_ROUNDS, TOTAL_FULL_ROUNDS, WIDTH,
 };
@@ -20,14 +21,15 @@ pub use scalar::ScalarStrategy;
 
 /// Defines the Hades252 strategy algorithm.
 pub trait Strategy<T: Clone> {
-    /// Computes `input ^ 5 (mod Fp)`
+    /// Computes `input ^ 5 (mod Fq)`
     ///
     /// The modulo depends on the input you use. In our case
-    /// the modulo is done in respect of the `curve25519 scalar field`
-    ///  == `2^252 + 27742317777372353535851937790883648493`.
+    /// the modulo is done in respect of the `bls12_381 scalar field`
+    ///  == `0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`.
     fn quintic_s_box(&mut self, value: &mut T);
 
-    /// Multiply the values for MDS matrix.
+    /// Multiply the values for MDS matrix during the
+    /// full rounds application.
     fn mul_matrix(&mut self, values: &mut [T]);
 
     /// Add round keys to a set of `StrategyInput`.
@@ -41,7 +43,8 @@ pub trait Strategy<T: Clone> {
     where
         I: Iterator<Item = &'b BlsScalar>;
 
-    /// Multiply the values for MDS matrix.
+    /// Multiply the values for MDS matrix during the
+    /// partial rounds application.
     fn mul_matrix_partial_round(&mut self, constants: &[BlsScalar], values: &mut [T]) {
         let size = values.len() - 1;
         self.add_round_key(&mut constants.iter(), &mut values[0..size]);


### PR DESCRIPTION
As stated in #42 we needed to refactor the docs in order to successfully migrate to the new plonk version as stated in #43 .


This removes all of the old comments and updates or extends them as well as adding Gadget examples on the readme.