### PR TITLE
Hades252 v0.5 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+
+## [0.5.0] - 11-05-20
+
+### Added
 - `dusk-plonk_v0.1.0` as proving system.
 - `dusk-bls12_381_v0.1.0` as curve-backend
 
@@ -14,10 +25,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GadgetStrategy` structure refactor & optimization.
 - tests updated & refactored with the new proving system.
 
+### Fixed
+
 ### Removed
 - `Bulletproofs` is no longer the proving system used.
 - `Curve25519-dalek` is no longer used as curve-backend.
 
+## [0.4.0] - 12-04-20
+
+### Added
+- Plonk/fast_prover_zexe backend for ZK-Gadget functions
+- Algebra, poly_commit & num_traits from Zexe as dependencies to work with PLONK.
+
+### Changed
+- Refactored the tests to work with the new ZK-Proof algorithm Plonk.
+
+### Fixed
+- Reduced the size of the circuit produced by reducing some gates that could be merged.
+
+### Removed
+- Bulletproofs dependencies removal.
+- Curve25519 dependencies removal.
+
+
+## [0.3.0] - 21-03-20
+
+### Added
+
+### Changed
+- Bulletproofs dependencies change to use dusk-network/bulletproofs "branch=develop".
+
+### Fixed
+
+### Removed
+
+
+## [0.2.0] - 15-03-20
+
+### Added
+
+### Changed
+- Bulletproofs dependencies change to use dusk-network/bulletproofs "branch=dalek_v2".
+
+### Fixed
+
+### Removed
 
 ## [0.1.0] - 27-02-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to plonk
+# Contributing to Hades252
 
 All of the code under this repository is licensed under the
 Mozilla Public License Version 2.0.
@@ -30,7 +30,8 @@ or the issue (or by email if you prefer it by any reason.)
 
 - Be descriptive in the titles of your PRs and also provide good descriptions about
 which things are being added, changed, fixed or removed also addressing the corresponding
-issue that it is addressing to.
+issue that it is addressing to. 
+See [How to Write a Git Commit Message]( https://chris.beams.io/posts/git-commit/) for more info.
 
 - Any pull request that it's not passing our CI tests & builds will not be merged. 
 This implies incorrect formatting errors, compilation errors, clippy lints, or any

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hades252"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
   "kev <kevtheappdev@gmail.com>", "zer0 <matteo@dusk.network>",
   "Victor Lopes <victor@dusk.network>", "kr0 <c.perezbaro@gmail.com>"
@@ -29,7 +29,6 @@ criterion = "0.3"
 merlin = "2"
 
 [build-dependencies]
-num-traits = "0.2"
 sha2 = "0.8"
 dusk-bls12_381 = "0.1.0"
 


### PR DESCRIPTION
- Updated CONTRIBUTING.md to refer to https://chris.beams.io/posts/git-commit/

- Re-written the CHANGELOG to be up to date with the GitHub tags & version releases.

- Updated `Cargo.toml` version to 0.5 & remove old dependencies that were still there.

## [0.5.0] - 11-05-20

### Added
- `dusk-plonk_v0.1.0` as proving system.
- `dusk-bls12_381_v0.1.0` as curve-backend

### Changed
- `GadgetStrategy` structure refactor & optimization.
- tests updated & refactored with the new proving system.

### Fixed

### Removed
- `Bulletproofs` is no longer the proving system used.
- `Curve25519-dalek` is no longer used as curve-backend.