### PR TITLE
Remove legacy poseidon functions from the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated the `dusk-plonk` versions to `v0.2.7`.
+
+### Removed
+- Legacy methods to perform `poseidon-based ops` such as hashing
+which is not the purpose of this lib.
+
 
 ## [0.6.1] - 24-07-20
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ build="build/build.rs"
 
 [dependencies]
 lazy_static = "1.3.0"
-dusk-plonk = "0.2.0"
+dusk-plonk = "0.2.7"
 
 [features]
 nightly_docs = []
@@ -26,7 +26,7 @@ criterion = "0.3"
 
 [build-dependencies]
 sha2 = "0.8"
-dusk-plonk = "0.2.1"
+dusk-plonk = "0.2.7"
 
 [profile.release]
 panic = 'abort'

--- a/src/strategies/gadget.rs
+++ b/src/strategies/gadget.rs
@@ -39,23 +39,6 @@ impl<'a> GadgetStrategy<'a> {
             );
         }
     }
-
-    /// Perform the poseidon hash on a plonk circuit
-    pub fn poseidon_gadget(
-        composer: &'a mut StandardComposer,
-        inputs: &mut [Variable],
-    ) -> Variable {
-        GadgetStrategy::hades_gadget(composer, inputs);
-        inputs[1]
-    }
-
-    /// Perform the poseidon slice hash on a plonk circuit
-    pub fn poseidon_slice_gadget(composer: &'a mut StandardComposer, x: &[Variable]) -> Variable {
-        let mut strategy = GadgetStrategy::new(composer);
-
-        let res_var: Variable = strategy.poseidon_slice(x);
-        res_var
-    }
 }
 
 impl<'a> Strategy<Variable> for GadgetStrategy<'a> {
@@ -276,35 +259,6 @@ impl<'a> Strategy<Variable> for GadgetStrategy<'a> {
                 WIDTH
             );
         }
-    }
-
-    /// Perform a slice strategy
-    fn poseidon_slice(&mut self, data: &[Variable]) -> Variable {
-        // Declare and constraint zero.
-        let zero = self.cs.add_input(BlsScalar::zero());
-        self.cs
-            .constrain_to_constant(zero, BlsScalar::zero(), BlsScalar::zero());
-
-        let mut perm = [zero; WIDTH];
-
-        let mut elements = [zero; WIDTH - 2];
-        elements
-            .iter_mut()
-            .enumerate()
-            .for_each(|(i, e)| *e = self.cs.add_input(BlsScalar::from((i + 1) as u64)));
-
-        data.chunks(WIDTH - 2).fold(zero, |r, chunk| {
-            perm[0] = elements[chunk.len() - 1];
-            perm[1] = r;
-
-            chunk
-                .iter()
-                .zip(perm.iter_mut().skip(2))
-                .for_each(|(c, p)| *p = *c);
-
-            let var_res: Variable = self.poseidon(&mut perm);
-            var_res
-        })
     }
 }
 

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -148,13 +148,4 @@ pub trait Strategy<T: Clone + Copy> {
             self.apply_full_round(&mut constants_iter, data);
         }
     }
-
-    /// Perform a poseidon hash
-    fn poseidon(&mut self, data: &mut [T]) -> T {
-        self.perm(data);
-        data[1]
-    }
-
-    /// Perform a slice strategy
-    fn poseidon_slice(&mut self, data: &[T]) -> T;
 }

--- a/src/strategies/scalar.rs
+++ b/src/strategies/scalar.rs
@@ -41,23 +41,6 @@ impl Strategy<BlsScalar> for ScalarStrategy {
             *w += constants.next().unwrap_or(&BlsScalar::one());
         });
     }
-
-    /// Perform a slice strategy
-    fn poseidon_slice(&mut self, data: &[BlsScalar]) -> BlsScalar {
-        let mut perm = [BlsScalar::zero(); WIDTH];
-
-        data.chunks(WIDTH - 2).fold(BlsScalar::zero(), |r, chunk| {
-            perm[0] = BlsScalar::from(chunk.len() as u64);
-            perm[1] = r;
-
-            chunk
-                .iter()
-                .zip(perm.iter_mut().skip(2))
-                .for_each(|(c, p)| *p = *c);
-
-            self.poseidon(&mut perm)
-        })
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As it is stated in #58 we never use this methods from this
library since they're moved to `Poseidon252` lib.

The implementations weren't even tested. So this is a clean up
of these old functions.

Closes #58