### PR TITLE
Bump to v0.11.0

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -21,35 +21,6 @@ jobs:
         with:
           command: dusk-analyzer
 
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-
-  test_stable:
-    name: Stable tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
-
   test_nightly:
     name: Nightly tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,95 +7,127 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.1] - 09-11-20
+## [0.11.0] - 2020-01-26
+
 ### Changed
+
+- Bump `dusk-plonk` to `v0.4`
+- Bump `dusk-bls12_381` to `v0.5`
+- Update CHANGELOG to ISO 8601
+
+## [0.10.1] - 2020-11-09
+
+### Changed
+
 - Update to support full no-std.
 
-## [0.10.0] - 06-10-20
+## [0.10.0] - 2020-10-06
+
 ### Fixed
+
 - Fixes #69 - ARK on partial round must be applied to all elements.
 
-## [0.9.0] - 05-10-20
-### Changed
-- Major optimization on `GadgetStrategy` with fan-in-3 feature of PLONK.
-    Gates per permutation set to `973`
+## [0.9.0] - 2020-10-05
 
-## [0.8.1] - 04-10-20
 ### Changed
+
+- Major optimization on `GadgetStrategy` with fan-in-3 feature of PLONK.
+  Gates per permutation set to `973`
+
+## [0.8.1] - 2020-10-04
+
+### Changed
+
 - Optimize `GadgetStrategy` to consume less gates.
 
-## [0.8.0] - 29-09-20
+## [0.8.0] - 2020-09-29
+
 ### Changed
+
 - Bump `dusk-plonk` to `v0.2.11`.
 
-## [0.7.0] - 13-08-20
+## [0.7.0] - 2020-08-13
+
 ### Added
+
 - `anyhow` crate to support Error handling in the tests.
 
 ### Changed
+
 - Updated the `dusk-plonk` versions to `v0.2.7`.
 
 ### Removed
+
 - Legacy methods to perform `poseidon-based ops` such as hashing
-which is not the purpose of this lib.
+  which is not the purpose of this lib.
 
+## [0.6.1] - 2020-07-24
 
-## [0.6.1] - 24-07-20
 ### Changed
+
 - `dusk-plonk` crate version to `0.2.1`.
 
-## [0.6.0] - 21-07-20
+## [0.6.0] - 2020-07-21
+
 ### Changed
+
 - `dusk-plonk` crate version to `v0.2.0`
 - Tests for gadgets now use the Prover&Verifier abstraction.
 
 ### Removed
+
 - `dusk-bls12_381` deps which are now taken from plonk's re-exported ones.
 
-## [0.5.0] - 11-05-20
+## [0.5.0] - 2020-05-11
 
 ### Added
+
 - `dusk-plonk_v0.1.0` as proving system.
 - `dusk-bls12_381_v0.1.0` as curve-backend
 
 ### Changed
+
 - `GadgetStrategy` structure refactor & optimization.
 - tests updated & refactored with the new proving system.
 
 ### Removed
+
 - `Bulletproofs` is no longer the proving system used.
 - `Curve25519-dalek` is no longer used as curve-backend.
 
-## [0.4.0] - 12-04-20
+## [0.4.0] - 2020-04-12
 
 ### Added
+
 - Plonk/fast_prover_zexe backend for ZK-Gadget functions
 - Algebra, poly_commit & num_traits from Zexe as dependencies to work with PLONK.
 
 ### Changed
+
 - Refactored the tests to work with the new ZK-Proof algorithm Plonk.
 
 ### Fixed
+
 - Reduced the size of the circuit produced by reducing some gates that could be merged.
 
 ### Removed
+
 - Bulletproofs dependencies removal.
 - Curve25519 dependencies removal.
 
-
-## [0.3.0] - 21-03-20
+## [0.3.0] - 2020-03-21
 
 ### Changed
+
 - Bulletproofs dependencies change to use dusk-network/bulletproofs "branch=develop".
 
-
-
-## [0.2.0] - 15-03-20
+## [0.2.0] - 2020-03-15
 
 ### Changed
+
 - Bulletproofs dependencies change to use dusk-network/bulletproofs "branch=dalek_v2".
 
-## [0.1.0] - 27-02-20
+## [0.1.0] - 2020-02-27
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hades252"
-version = "0.10.1"
+version = "0.11.0"
 authors = [
   "kev <kevtheappdev@gmail.com>", "zer0 <matteo@dusk.network>",
   "Victor Lopes <victor@dusk.network>", "kr0 <c.perezbaro@gmail.com>"
@@ -10,13 +10,14 @@ build="build/build.rs"
 
 [dependencies]
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-dusk-bls12_381 = { version = "0.3", default-features = false }
-dusk-plonk = { version = "0.3", optional = true }
+dusk-bls12_381 = { version = "0.5", default-features = false }
+dusk-plonk = { version = "0.4", optional = true }
 
 [dev-dependencies]
 rand = "0.7"
 criterion = "0.3"
-anyhow = "1.0.0"
+anyhow = "1.0"
+dusk-bytes = "0.1"
 
 [build-dependencies]
 sha2 = "0.8"

--- a/src/round_constants.rs
+++ b/src/round_constants.rs
@@ -57,7 +57,7 @@ lazy_static! {
 mod test {
     use super::ROUND_CONSTANTS;
     use dusk_bls12_381::BlsScalar;
-
+    use dusk_bytes::Serializable;
     #[test]
     fn test_round_constants() {
         // Check each element is non-zero


### PR DESCRIPTION
- Bump `dusk-plonk` to `v0.4`
- Bump `dusk-bls12_381` to `v0.5`
- Use ISO 8601 in the CHANGELOG
- Remove stable tests & check from CI