### PR TITLE
Update & Change deps & dev-deps to newest/alternative versions + no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated `dusk-bls12_381` & `dusk-plonk` to latest versions. [#84](https://github.com/dusk-network/Hades252/issues/84)
+- Replaced `rand` by `rand-core`. [#86](https://github.com/dusk-network/Hades252/issues/86)
+- Make repo no_std with `alloc` feature. [#87](https://github.com/dusk-network/Hades252/issues/87)
+  
+### Removed
+- Removed `anyhow` from dev-deps`. [#85](https://github.com/dusk-network/Hades252/issues/85)
+
 ## [0.15.0] - 2021-04-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ codegen-units = 1
 default = ["alloc"]
 alloc = ["dusk-plonk/alloc"]
 std = [
+        "alloc",
         "dusk-plonk/default",
         "dusk-bls12_381/default",
         "rand_core/std"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ std = [
         "alloc",
         "dusk-plonk/default",
         "dusk-bls12_381/default",
-        "rand_core/std"
       ]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ build="build/build.rs"
 [dependencies]
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 dusk-bls12_381 = { version = "0.8.0-rc.0", default-features = false }
-dusk-plonk = { version="0.7",default-features = false, optional = true }
+dusk-plonk = { version="0.8.0-rc.1",default-features = false, optional = true }
 
 [dev-dependencies]
 rand_core = {version = "0.6",default-features = false}
-criterion = "0.3"
 dusk-bytes = "0.1"
 
 [build-dependencies]
@@ -36,13 +35,8 @@ codegen-units = 1
 [features]
 default = ["alloc"]
 alloc = ["dusk-plonk/alloc"]
-std = [
+plonk-std = [
         "alloc",
         "dusk-plonk/default",
         "dusk-bls12_381/default",
       ]
-
-
-
-[patch.crates-io]
-dusk-plonk = {path = "../plonk",default-features = false, optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ dusk-bls12_381 = { version = "0.8.0-rc.0", default-features = false }
 dusk-plonk = { version="0.7",default-features = false, optional = true }
 
 [dev-dependencies]
-rand_core = "0.6"
+rand_core = {version = "0.6",default-features = false}
 criterion = "0.3"
 dusk-bytes = "0.1"
 
@@ -39,6 +39,7 @@ alloc = ["dusk-plonk/alloc"]
 std = [
         "dusk-plonk/default",
         "dusk-bls12_381/default",
+        "rand_core/std"
       ]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,21 @@ categories = ["algorithms", "cryptography", "no-std", "wasm"]
 keywords = ["cryptography", "zero-knowledge", "crypto"]
 license = "MPL-2.0"
 repository = "https://github.com/dusk-network/hades252"
-
 build="build/build.rs"
 
 [dependencies]
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-dusk-bls12_381 = { version = "0.6", default-features = false }
-dusk-plonk = { version="0.7", optional = true }
+dusk-bls12_381 = { version = "0.8.0-rc.0", default-features = false }
+dusk-plonk = { version="0.7",default-features = false, optional = true }
 
 [dev-dependencies]
-rand = "0.7"
+rand_core = "0.6"
 criterion = "0.3"
-anyhow = "1.0"
 dusk-bytes = "0.1"
 
 [build-dependencies]
 sha2 = "0.8"
-dusk-bls12_381 = { version = "0.6", default-features = false }
+dusk-bls12_381 = { version = "0.8.0-rc.0"}
 
 [profile.release]
 panic = 'abort'
@@ -36,5 +34,14 @@ incremental = false
 codegen-units = 1
 
 [features]
-default = ["std"]
-std = ["dusk-plonk", "dusk-bls12_381/default"]
+default = ["alloc"]
+alloc = ["dusk-plonk/alloc"]
+std = [
+        "dusk-plonk/default",
+        "dusk-bls12_381/default",
+      ]
+
+
+
+[patch.crates-io]
+dusk-plonk = {path = "../plonk",default-features = false, optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@
 #![deny(missing_docs)]
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 mod mds_matrix;
 mod round_constants;
@@ -26,6 +29,6 @@ pub const PARTIAL_ROUNDS: usize = 59;
 /// Maximum input width for the rounds
 pub const WIDTH: usize = 5;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use strategies::GadgetStrategy;
 pub use strategies::{ScalarStrategy, Strategy};

--- a/src/strategies/gadget.rs
+++ b/src/strategies/gadget.rs
@@ -135,10 +135,11 @@ impl<'a> Strategy<Variable> for GadgetStrategy<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{GadgetStrategy, ScalarStrategy, Strategy, WIDTH};
-
-    use anyhow::Result;
+    use alloc::vec::Vec;
+    use core::mem;
+    use core::result::Result;
     use dusk_plonk::prelude::*;
-    use std::mem;
+    use rand_core::OsRng;
 
     fn perm(values: &mut [BlsScalar]) {
         let mut strategy = ScalarStrategy::new();
@@ -146,14 +147,14 @@ mod tests {
     }
 
     #[test]
-    fn hades_preimage() -> Result<()> {
+    fn hades_preimage() -> Result<(), Error> {
         const CAPACITY: usize = 2048;
 
         fn hades() -> ([BlsScalar; WIDTH], [BlsScalar; WIDTH]) {
             let mut input = [BlsScalar::zero(); WIDTH];
             input
                 .iter_mut()
-                .for_each(|s| *s = BlsScalar::random(&mut rand::thread_rng()));
+                .for_each(|s| *s = BlsScalar::random(&mut OsRng));
             let mut output = [BlsScalar::zero(); WIDTH];
             output.copy_from_slice(&input);
             ScalarStrategy::new().perm(&mut output);
@@ -200,11 +201,11 @@ mod tests {
             });
 
             composer.add_dummy_constraints();
-            vec![BlsScalar::zero()]
+            alloc::vec![BlsScalar::zero()]
         }
 
         // Setup OG params.
-        let public_parameters = PublicParameters::setup(CAPACITY, &mut rand::thread_rng())?;
+        let public_parameters = PublicParameters::setup(CAPACITY, &mut OsRng)?;
         let (ck, vk) = public_parameters.trim(CAPACITY)?;
 
         let (i, o) = hades();

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -17,13 +17,13 @@ use crate::{round_constants::ROUND_CONSTANTS, PARTIAL_ROUNDS, TOTAL_FULL_ROUNDS}
 use dusk_bls12_381::BlsScalar;
 
 /// Strategy for zero-knowledge plonk circuits
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod gadget;
 
 /// Strategy for scalars
 pub mod scalar;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use gadget::GadgetStrategy;
 pub use scalar::ScalarStrategy;
 


### PR DESCRIPTION
- Updated bls & plonk to latest versions.
- Replaced rand by rand-core
- Removed `anyhow` from dev-deps`
- Make repo no_std with `alloc` feature

Everything has been done on the same PR to since split the `no_std` and the version changes will have been more tricky since both relayed on each other.

 Resolves: #84, #85, #86, #87