### PR TITLE
Bump to v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2023-10-11
+
+## Changed
+
+- Update `dusk-plonk` to 0.16
+- Update `dusk-bls12_381` to 0.12
+
 ## [0.21.0] - 2023-06-28
 
 ### Changed
@@ -214,7 +221,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#84]: https://github.com/dusk-network/Hades252/issues/84
 
 <!-- VERSIONS -->
-[unreleased]: https://github.com/dusk-network/dusk-abi/compare/v0.21.0...HEAD
+[unreleased]: https://github.com/dusk-network/dusk-abi/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/dusk-network/dusk-abi/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/dusk-network/dusk-abi/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/dusk-network/dusk-abi/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/dusk-network/dusk-abi/compare/v0.16.0...v0.19.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-hades"
-version = "0.21.0"
+version = "0.22.0"
 authors = [
   "kev <kevtheappdev@gmail.com>", "zer0 <matteo@dusk.network>",
   "Victor Lopes <victor@dusk.network>", "kr0 <c.perezbaro@gmail.com>"


### PR DESCRIPTION
## [0.22.0] - 2023-10-11

## Changed

- Update `dusk-plonk` to 0.16
- Update `dusk-bls12_381` to 0.12

[0.22.0]: https://github.com/dusk-network/dusk-abi/compare/v0.21.0...v0.22.0
