### PR TITLE
Release `0.22.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2023-11-22
+
+### Fixed
+
+- Clippy fixes
+
 ## [0.22.0] - 2023-10-11
 
 ## Changed
@@ -221,7 +227,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#84]: https://github.com/dusk-network/Hades252/issues/84
 
 <!-- VERSIONS -->
-[unreleased]: https://github.com/dusk-network/dusk-abi/compare/v0.22.0...HEAD
+[unreleased]: https://github.com/dusk-network/dusk-abi/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/dusk-network/dusk-abi/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/dusk-network/dusk-abi/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/dusk-network/dusk-abi/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/dusk-network/dusk-abi/compare/v0.19.0...v0.20.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-hades"
-version = "0.22.0"
+version = "0.22.1"
 authors = [
   "kev <kevtheappdev@gmail.com>", "zer0 <matteo@dusk.network>",
   "Victor Lopes <victor@dusk.network>", "kr0 <c.perezbaro@gmail.com>"


### PR DESCRIPTION
## [0.22.1] - 2023-11-22

### Fixed

- Clippy fixes

[0.22.1]: https://github.com/dusk-network/dusk-abi/compare/v0.22.0...v0.22.1