### PR TITLE
Bump to 0.24.1 which deprecates the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2024-01-24
+
 ### Changed
 
 - Add deprecation notice [#120]
@@ -245,7 +247,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#84]: https://github.com/dusk-network/Hades252/issues/84
 
 <!-- VERSIONS -->
-[unreleased]: https://github.com/dusk-network/dusk-abi/compare/v0.24.0...HEAD
+[unreleased]: https://github.com/dusk-network/dusk-abi/compare/v0.24.1...HEAD
+[0.24.1]: https://github.com/dusk-network/dusk-abi/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/dusk-network/dusk-abi/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/dusk-network/dusk-abi/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/dusk-network/dusk-abi/compare/v0.22.0...v0.22.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-hades"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 description ="Implementation of Hades252 permutation algorithm over the Bls12-381 Scalar field."
 categories = ["algorithms", "cryptography", "no-std", "wasm"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 # Hades252 (deprecated)
 
-**This crate is not in active development anymore. The functionalities of this crate moved into [`dusk-poseidon`](https://github.com/dusk-network/Poseidon252).**
+| :exclamation: This crate is deprecated. |
+|---------------------------------------------|
+The hades permutation moved into [`dusk-poseidon`](https://github.com/dusk-network/Poseidon252).
 
 Implementation of Hades252 permutation algorithm over the Bls12-381 Scalar field.
 


### PR DESCRIPTION
## [0.24.1] - 2024-01-24

### Changed

- Add deprecation notice [#120]


[0.24.1]: https://github.com/dusk-network/dusk-abi/compare/v0.24.0...v0.24.1
